### PR TITLE
Use fake timers in test to avoid unreliable test behavior

### DIFF
--- a/example.test.js
+++ b/example.test.js
@@ -13,19 +13,22 @@ function Comp() {
   return null
 }
 
-test('example', async () => {
+test('example', () => {
   const container = document.createElement('div')
 
   // using `act` is required to get effect callbacks run when rendering components
   // (React Testing Library does this automatically)
+  jest.useFakeTimers()
+  ReactDOM.render(React.createElement(Comp), container)
+
   act(() => {
-    ReactDOM.render(React.createElement(Comp), container)
+    jest.runAllTimers()
   })
 
   // the `cleanup` function from React Testing Library (which also happens automatically)
   // flushes all the in-flight effects by waiting for the next tick of the event loop
   // this is basically a simplified version of: https://github.com/facebook/react/blob/master/packages/shared/enqueueTask.js
-  await new Promise((resolve) => setImmediate(resolve))
+  // await new Promise((resolve) => setImmediate(resolve))
 
   // this is the last thing that happens in cleanup (to avoid memory leaks)
   ReactDOM.unmountComponentAtNode(container)


### PR DESCRIPTION
Not sure why specifically this is happening, but making this render use fake timers when running effects removes the nondeterminism from this test. I think now this test can also remove the promise flushing, since the effects are invoked and the timeout is executed with the `act`-- not absolutely positive on this one, but I ran it a ton of times and it never failed. This test also still works if the flushing of promises is kept in there too, so no harm done with it if it's necessary for some other reason.

Hope this helps! I pretty much always use fake timers whenever I have any set(Timeout|Interval) stuff going on and I've had good luck avoiding stuff like this. I'm not 100% sure if jest still isn't cleaning things up completely, but hopefully, it should be able to reset its own state of `useFakeTimers` easier than it can clear all timeouts